### PR TITLE
Use CURLOPT_REDIR_PROTOCOLS_STR when curl >= 7.85.0

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -1007,10 +1007,17 @@ bool oauth2_http_call(oauth2_log_t *log, const char *url, const char *data,
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&buf);
 
 #ifndef LIBCURL_NO_CURLPROTO
+#if CURL_AT_LEAST_VERSION(7,85,0)
+	curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR,
+			 "http,https");
+	curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR,
+			 "http,https");
+#else
 	curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS,
 			 CURLPROTO_HTTP | CURLPROTO_HTTPS);
 	curl_easy_setopt(curl, CURLOPT_PROTOCOLS,
 			 CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
 #endif
 
 	if (ctx) {


### PR DESCRIPTION
The patch fixes `oauth2_http_call` in `src/http.c` for newer version of curl, where the options `CURLOPT_REDIR_PROTOCOLS` and `CURLOPT_PROTOCOLS` need to be replaced with `CURLOPT_REDIR_PROTOCOLS_STR` and `CURLOPT_PROTOCOLS_STR`

See https://curl.se/libcurl/c/CURLOPT_REDIR_PROTOCOLS.html#AVAILABILITY