### PR TITLE
allow to use local file through file:// protocol for metadata or jwks

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -1014,12 +1014,12 @@ bool oauth2_http_call(oauth2_log_t *log, const char *url, const char *data,
 #ifndef LIBCURL_NO_CURLPROTO
 #if LIBCURL_VERSION_NUM >= 0x075500
 	curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
-	curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "http,https");
+	curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "http,https,file");
 #else
 	curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS,
 			 CURLPROTO_HTTP | CURLPROTO_HTTPS);
 	curl_easy_setopt(curl, CURLOPT_PROTOCOLS,
-			 CURLPROTO_HTTP | CURLPROTO_HTTPS);
+			 CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FILE);
 #endif
 #endif
 


### PR DESCRIPTION
This PR to allow usage of file:// protocol in various options so as to put key files or metadata on local storage rather than depending upon network.

It is useful in use-case where HTTP server is denied to connect to external services as it is the default on some OS with SELinux enabled (ie RHEL).

For example :
`OAuth2TokenVerify $source_token jwks_uri file:///etc/nginx/my_jwks.json ;`
